### PR TITLE
Set Elixir version to 1.8 to match other repos and avoid issues

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule MicroServiceWatchinator.MixProject do
     [
       app: :micro_service_watchinator,
       version: "1.0.0",
-      elixir: "~> 1.8.1",
+      elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases()


### PR DESCRIPTION
This PM aligns the Elixir version to match the other repos. 

Other Smart Cities Data repos set the required Elixir version to `"~> 1.8"`. This repo currently sets it to `"~> 1.8.1"`. This causes it to generate the following error when running in later versions of Elixir:

```
$ mix test
** (Mix) You're trying to run :micro_service_watchinator on Elixir v1.9.4 but it has declared in its mix.exs file it supports only Elixir ~> 1.8.1
```

Set the value to `"~> 1.8"`, matching the other repos, and this issue goes away:

```
$ mix test

08:39:47.475 [info]  Initiating web check against wss://foo.noop/socket/websocket

08:39:47.478 [info]  Successfully Made Socket Connection
.
08:39:47.724 [info]  Initiating web check against wss://foo.noop/socket/websocket

08:39:47.724 [info]  Successfully Made Socket Connection

08:39:47.734 [info]  %{metrics: [%{dimensions: [{"ApplicationName", "Cota-Streaming-Consumer"}], metric_name: "Opened", timestamp: ~U[2019-11-11 13:39:47.730486Z], unit: "Count", value: 1}], namespace: "Socket Connection"}
.
08:39:47.955 [info]  Initiating web check against wss://foo.noop/socket/websocket

08:39:47.955 [warn]  Failed to make a socket connection
.

Finished in 0.8 seconds
3 tests, 0 failures

Randomized with seed 112746
```